### PR TITLE
Build images for several architectures

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,22 +4,48 @@ on:
   schedule:
   - cron: "20 19 * * *"
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      BUILD_VERSION:
+        description: 'Build version'
+        required: true
+        default: '1839'
+      BUILD_SHA512SUM:
+        description: 'SHA512 hash'
+        required: true
+        default: '7266fb1613adbe0d652497aa189fb1ab5d80fe7da7182c4365dd54f71c0f3248b750400a5049f2a63ab18df2ea4a7fad981ba7f3a1b24e5760adea76d1a527ca'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      BUILD_VERSION: 1822
-      BUILD_SHA1SUM: c84341b409672d3617300a0348fc81ff21453433
+      BUILD_AUTHORS: "Kane 'kawaii' Valentine <kawaii@mybb.com>"
+      BUILD_VERSION: ${{ github.event.inputs.BUILD_VERSION }}
+      BUILD_SHA512SUM: ${{ github.event.inputs.BUILD_SHA512SUM }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build the Docker image
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build multi-arch Docker image
         run: |
-          docker build \
-            --build-arg BUILD_AUTHORS="Kane 'kawaii' Valentine <kawaii@mybb.com>" \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg BUILD_AUTHORS="$BUILD_AUTHORS" \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            --build-arg BUILD_SHA1SUM=$BUILD_SHA1SUM \
+            --build-arg BUILD_SHA512SUM=$BUILD_SHA512SUM \
             --build-arg BUILD_VERSION=$BUILD_VERSION \
-            --tag mybb/mybb:$BUILD_VERSION \
-            --tag mybb/mybb:latest \
+            --tag ghcr.io/mybb/mybb:$BUILD_VERSION \
+            --tag ghcr.io/mybb/mybb:latest \
+            --push \
           $PWD

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,14 +72,15 @@ RUN { \
                 echo 'memory_limit=256M'; \
         } > /usr/local/etc/php/conf.d/mybb-recommended.ini
 
-ENV MYBB_VERSION $BUILD_VERSION
-ENV MYBB_SHA512 $BUILD_SHA512SUM
+ENV MYBB_VERSION=$BUILD_VERSION
+ENV MYBB_SHA512=$BUILD_SHA512SUM
 
 RUN set -ex; \
-	curl -o mybb.tar.gz -fSL "https://github.com/mybb/mybb/archive/refs/tags/mybb_${MYBB_VERSION}.tar.gz"; \
-	echo "$MYBB_SHA512 *mybb.tar.gz" | sha512sum -c -; \
-	tar -xzf mybb.tar.gz -C /usr/src/; \
-	rm mybb.tar.gz; \
+	curl -o mybb.zip -fSL "https://github.com/mybb/mybb/releases/download/mybb_1839/mybb_${MYBB_VERSION}.zip"; \
+	echo "$MYBB_SHA512 *mybb.zip" | sha512sum -c -; \
+	unzip mybb.zip; \
+	mv Upload /usr/src/mybb-mybb_${MYBB_VERSION}; \
+	rm -rf mybb.zip Documentation; \
 	chown -R www-data:www-data /usr/src/mybb-mybb_${MYBB_VERSION}
 
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## What / Why

Uses .zip instead of .tar.gz files
  
This allows using the [official .zip and its related checksums](https://mybb.com/versions/1.8.39/) (SHA512)
  
  Also:
  
   * Adds optional manual build trigger from the GitHub Workflows page
   * Build for both `linux/amd64` and `linux/arm64` in parallel
   * Publish the image to GitHub Container Registry (ghcr.io) instead of docker  (tags only tested in my account)

